### PR TITLE
Add ACR identity block

### DIFF
--- a/r-acr.tf
+++ b/r-acr.tf
@@ -15,6 +15,14 @@ resource "azurerm_container_registry" "main" {
   trust_policy_enabled     = var.sku == "Premium" ? var.trust_policy_enabled : false
   zone_redundancy_enabled  = var.zone_redundancy_enabled
 
+  dynamic "identity" {
+    for_each = var.identity[*]
+    content {
+      type         = var.identity.type
+      identity_ids = endswith(var.identity.type, "UserAssigned") ? var.identity.identity_ids : null
+    }
+  }
+
   dynamic "georeplications" {
     for_each = var.georeplication_locations != null && var.sku == "Premium" ? var.georeplication_locations : []
 

--- a/variables.tf
+++ b/variables.tf
@@ -101,3 +101,13 @@ variable "zone_redundancy_enabled" {
   default     = false
   type        = bool
 }
+
+variable "identity" {
+  description = "Identity block information."
+  type = object({
+    type         = optional(string, "SystemAssigned")
+    identity_ids = optional(list(string))
+  })
+  default  = {}
+  nullable = false
+}


### PR DESCRIPTION
Option to modify identity exists in `azurerm_container_registry` [resource](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry#type-1)

However, it's not modifiable in [the ACR module](https://github.com/claranet/terraform-azurerm-acr/blob/master/r-acr.tf).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- parametrize ACR identity to pass it to module as variables (like in other claranet modules, e.g., for [storage account](https://github.com/claranet/terraform-azurerm-storage-account/blob/master/r-storage-account.tf#L30-L36))

@claranet/fr-azure-reviewers
